### PR TITLE
Add Access-Control-Expose-Headers header

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ app.use((req, res, next) => {
     'Origin, X-Requested-With, Content-Type, Accept, Authorization, Access-Control-Allow-Credentials'
   );
   res.header('Access-Control-Allow-Credentials', 'true');
+  res.header('Access-Control-Expose-Headers', 'per-page, page-number, total-entries, total-pages');
   next();
 });
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#access-control-expose-headers

Have to expose those custom headers so the front end can access them.